### PR TITLE
fix: add_accountinitのlambda修正

### DIFF
--- a/src/lambda/disable-securityhub.lambda.ts
+++ b/src/lambda/disable-securityhub.lambda.ts
@@ -6,7 +6,7 @@ import {
 type EventProps = {
   accountId: string;
   region: string;
-  swroleResultPath: {
+  swRoleResultPath: {
     Payload: {
       AccessKeyId: string;
       SecretAccessKey: string;
@@ -25,7 +25,7 @@ const controlTowerHomeRegion = process.env.controlTowerHomeRegion!;
 export async function handler(event: EventProps) {
   const { accountId, region } = event;
   const { AccessKeyId, SecretAccessKey, SessionToken } =
-    event.swroleResultPath.Payload;
+    event.swRoleResultPath.Payload;
   const sechubClient = new SecurityHubClient({
     region: region,
     credentials: {


### PR DESCRIPTION
## TL;DR
exec側から実行してエラーとなったため修正

## チケット / Slack のリンク
https://justincase.myjetbrains.com/youtrack/issue/SRE-1257

## 作成・更新・削除される AWS 等のリソース
なし

## Merge 前後で必要な作業（もしあれば）

## レビュー箇所


## エビデンス(構築したリソースが動いているところのスクリーンショットなど)
lambda内へ命名変更が反映されていないことが原因と考えられる
<img width="243" alt="image" src="https://user-images.githubusercontent.com/26247259/155530959-ffd9e2c0-887f-42a4-90b9-44d0f57545ae.png">

<img width="161" alt="image" src="https://user-images.githubusercontent.com/26247259/155531076-1465d697-10d6-4719-874c-9cc17c934d01.png">
